### PR TITLE
Fixed conditions for setting correct shape of scalar fields

### DIFF
--- a/fld_data.py
+++ b/fld_data.py
@@ -411,7 +411,8 @@ class FldData:
 
     @s.setter
     def s(self, other: np.ndarray):
-        if other.size != 0 and len(other.shape) != 2 and other.shape[1] != self.nelt * self.nx1 * self.ny1 * self.nz1:
+        if other.size != 0 and (len(other.shape) != 2 or other.shape[
+            1] != self.nelt * self.nx1 * self.ny1 * self.nz1):
             raise ValueError(
                 "Incorrect shape for s: s.shape must equal (x, nelt * nx1 * ny1 * nz1) for arbitrary number of scalars x")
         self._s = other.astype(self.float_type)


### PR DESCRIPTION
This fixes the error checking for setting the passive scalars in `FldData`.  

In the current master, when you try to set `FldData.s` to a 1D array, you get an unhelpful error:
``` pycon
>>> f = FldData.fromfile('demos/data/test0.f00001')
[demos/data/test0.f00001] : Attempting to fields from rdcode XUPTS02
[demos/data/test0.f00001] : Located coordinates X
[demos/data/test0.f00001] : Located velocity field U
[demos/data/test0.f00001] : Located pressure field P
[demos/data/test0.f00001] : Located temperature field T
[demos/data/test0.f00001] : Located 2 passive scalar fields
>>> f.s = np.array([1,1,1])
Traceback (most recent call last):
  File "/anaconda3/lib/python3.7/site-packages/IPython/core/interactiveshell.py", line 3267, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-5-bf5d14e68bad>", line 1, in <module>
    f.s = np.array([1,1,1])
  File "/Users/rahaman/repos/fld_pyutils/fld_data.py", line 414, in s
    if other.size != 0 and len(other.shape) != 2 and other.shape[1] != self.nelt * self.nx1 * self.ny1 * self.nz1:
IndexError: tuple index out of range
```

With this PR, the condition for the error check is corrected, and the resultant error is more descriptive:
``` pycon
>>> f = FldData.fromfile('demos/data/test0.f00001')
[demos/data/test0.f00001] : Attempting to fields from rdcode XUPTS02
[demos/data/test0.f00001] : Located coordinates X
[demos/data/test0.f00001] : Located velocity field U
[demos/data/test0.f00001] : Located pressure field P
[demos/data/test0.f00001] : Located temperature field T
[demos/data/test0.f00001] : Located 2 passive scalar fields
>>> f.s = np.array([1,1,1])
Traceback (most recent call last):
  File "/anaconda3/lib/python3.7/site-packages/IPython/core/interactiveshell.py", line 3267, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-6-bf5d14e68bad>", line 1, in <module>
    f.s = np.array([1,1,1])
  File "/Users/rahaman/repos/fld_pyutils/fld_data.py", line 416, in s
    "Incorrect shape for s: s.shape must equal (x, nelt * nx1 * ny1 * nz1) for arbitrary number of scalars x")
ValueError: Incorrect shape for s: s.shape must equal (x, nelt * nx1 * ny1 * nz1) for arbitrary number of scalars x
```