### PR TITLE
Fixed error checking if_press_mesh

### DIFF
--- a/fld_header.py
+++ b/fld_header.py
@@ -119,7 +119,7 @@ class FldHeader:
             # Set if_press_mesh               # default = F
             if header_list[13].casefold() == 'f':
                 if_press_mesh = False
-            elif header_list[13].casefold() == '_t':
+            elif header_list[13].casefold() == 't':
                 raise ValueError("{} specifies if_press_mesh='{}', but PnPn-2 is not supported for {}".format(
                     filename, header_list[13], cls.__name__))
             else:


### PR DESCRIPTION
I think there was a typo where `FldHeader` checks for the pressure mesh.  It believe it should be either "T" or "F" (case-insensitive), but I made a typo in the comparison.